### PR TITLE
adding optional default_tag_size_ param

### DIFF
--- a/apriltags2_ros/include/apriltags2_ros/common_functions.h
+++ b/apriltags2_ros/include/apriltags2_ros/common_functions.h
@@ -179,8 +179,10 @@ class TagDetector
   // Other members
   std::map<int, StandaloneTagDescription> standalone_tag_descriptions_;
   std::vector<TagBundleDescription > tag_bundle_descriptions_;
-  bool run_quietly_;
   bool publish_tf_;
+  bool run_quietly_;
+  bool use_default_tag_size_;
+  double default_tag_size_;
   tf::TransformBroadcaster tf_pub_;
   std::string camera_tf_frame_;
 


### PR DESCRIPTION
Allows for a default tag size via parameters. Setting default_tag_size parameter will cause any apriltag detections not account for in standalone_tags or bundle_tags parameters to be assigned the value provided by default_size as their size. This removes the current requirement that every individual apriltag that may be used be provided a size in a config file.